### PR TITLE
fix(install): resolve symlinks in main module detection

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -161,7 +161,9 @@ export async function install(config = {}) {
 }
 
 // Main execution - only runs when script is executed directly
-const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+// Use realpathSync to resolve symlinks (e.g., /tmp -> /private/tmp on macOS)
+// because import.meta.url resolves symlinks but process.argv[1] doesn't
+const isMainModule = import.meta.url === `file://${fs.realpathSync(process.argv[1])}`;
 if (isMainModule) {
   install().then((result) => {
     if (!result.success) {


### PR DESCRIPTION
## Summary
- Fix npx installation silently failing on macOS due to symlink path mismatch
- Use `fs.realpathSync` to resolve symlinks before comparing `import.meta.url` with `process.argv[1]`

## Problem
On macOS, `/tmp` is a symlink to `/private/tmp`. When running via `npx github:bardusco/opencode-conductor-bridge`:
- `import.meta.url` returns `file:///private/tmp/...` (resolved path)
- `process.argv[1]` returns `/tmp/...` (original path)

This caused the `isMainModule` check to always fail, resulting in the script silently not executing.

## Testing
- Verified fix works in `/tmp` test directory
- All 107 tests pass
- Coverage at 86.15%